### PR TITLE
fix: handle missing npm token in release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -37,7 +37,12 @@ jobs:
       - run: npm run build
         if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm publish --access public
+      - name: Publish to npm
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created && secrets.NODE_AUTH_TOKEN != '' }}
+
+      - name: Skip publish when token missing
+        if: ${{ steps.release.outputs.release_created && secrets.NODE_AUTH_TOKEN == '' }}
+        run: echo "NODE_AUTH_TOKEN is not configured; skipping npm publish step."


### PR DESCRIPTION
## Summary

- guard the npm publish step so releases are skipped when NODE_AUTH_TOKEN is not configured and provide a clear log message

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc40e40e988332bd8ba97db5eff68e