### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,12 +8,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required for npm trusted publishing via OIDC (no token needed)
+  id-token: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
@@ -26,8 +26,12 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+
+      # Trusted publishing requires npm >= 11.5.1 (newer than what Node bundles)
+      - run: npm install -g npm@latest
         if: ${{ steps.release.outputs.release_created }}
 
       - run: npm ci
@@ -39,12 +43,7 @@ jobs:
       - run: npm run build
         if: ${{ steps.release.outputs.release_created }}
 
+      # Publishes via OIDC trusted publishing; provenance is generated automatically
       - name: Publish to npm
-        if: ${{ steps.release.outputs.release_created && env.NODE_AUTH_TOKEN != '' }}
+        if: ${{ steps.release.outputs.release_created }}
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
-
-      - name: Skip publish when token missing
-        if: ${{ steps.release.outputs.release_created && env.NODE_AUTH_TOKEN == '' }}
-        run: echo "NODE_AUTH_TOKEN is not configured; skipping npm publish step."


### PR DESCRIPTION
## Summary

Switches the npm publish step in the Release Please workflow from **token-based auth** to **OIDC trusted publishing**, matching the npmjs.org configuration (OIDC enabled, tokens disallowed).

## Changes
- **Add `id-token: write`** permission — required for GitHub Actions to mint the OIDC token npm exchanges for publish auth.
- **Remove all token usage** — drop the job-level `NODE_AUTH_TOKEN` env, the token on the publish step, and the "skip publish when token missing" step. Publish now runs whenever a release is created.
- **Bump Node 20 → 22** and **add `npm install -g npm@latest`** — trusted publishing requires **npm ≥ 11.5.1 / Node ≥ 22.14.0**, newer than the npm bundled with Node.
- **Provenance** is now generated automatically (public repo + public package); no `--provenance` flag required.

## Required npmjs configuration (outside this repo)
For the next release to publish successfully, the package's **Trusted Publishers** settings on npmjs.org must list:
- Repository: `billchurch/bhyve-api`
- Workflow filename: `release-please.yaml`
- Environment: *(blank — this workflow uses no GitHub Environment)*

## Notes
- No PR-triggered CI exists for this repo, so this workflow only executes on push to `main`; it will first be exercised on the next release PR merge.
- `bhyve-api` already exists on npm, so the trusted-publishing "package must already exist" requirement is satisfied.

https://claude.ai/code/session_01PQ4ZARNp4gHHwQ81NxDfWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ4ZARNp4gHHwQ81NxDfWj)_